### PR TITLE
[BUGFIX] Check if causal_accounts is used in backend mode before it starts synchronization

### DIFF
--- a/Classes/4x/class.ux_tx_openid_sv1.php
+++ b/Classes/4x/class.ux_tx_openid_sv1.php
@@ -65,7 +65,7 @@ class ux_tx_openid_sv1 extends tx_openid_sv1 {
 	 * @return	void
 	 */
 	public function initAuth($subType, array $loginData, array $authenticationInformation, t3lib_userAuth &$parentObject) {
-		if ($this->initConfiguration()) {
+		if (TYPO3_MODE === 'BE' && $this->initConfiguration()) {
 			$this->synchronize();
 		}
 


### PR DESCRIPTION
We got the problem that "causal_accounts" tries to do something (we do not actually know what it tries exactly) while the frontend logging in. Due to the introduction of the documentation I do not think that this behaviour is correct. Because of that, I fixed this adding a TYPO3_MODE check.