### PR TITLE
[BUGFIX] EidUtility::initTCA() is needed with TYPO3 7 LTS

### DIFF
--- a/Classes/Controller/EidController.php
+++ b/Classes/Controller/EidController.php
@@ -55,6 +55,11 @@ class EidController
             $this->denyAccess();
         }
 
+        // Initialize TCA (method handles if not already initialized)
+        if (version_compare(TYPO3_version, '7.6', '>=')) {
+            \TYPO3\CMS\Frontend\Utility\EidUtility::initTCA();
+        }
+
         $this->initTSFE();
 
         if (!empty($this->config['synchronizeDeletedAccounts']) && $this->config['synchronizeDeletedAccounts']) {


### PR DESCRIPTION
Bugfixes EidController on master in TYPO3 7 LTS.
TCA is needed by a core method used during \Causal\CausalAccounts\Controller\EidController::initTSFE: \TYPO3\CMS\Frontend\Page\PageRepository::init